### PR TITLE
fix(ui): gradio 6 compat — drop show_copy_button, pin gradio<7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,10 @@ readme = "README.md"
 requires-python = "==3.11.*"
 dependencies = [
     "fastapi[standard]>=0.115.12",
-    "gradio>=5.33.1",
+    # Pin to gradio 6.x explicitly. The previous `>=5.33.1` would happily
+    # resolve to gradio 7+ and reintroduce silent breakage like the
+    # show_copy_button removal in 6.0.
+    "gradio>=6.0,<7",
     "librosa>=0.11.0",
     # NeMo + cuda-python are CUDA-only (Linux). On macOS the Parakeet
     # adapter's lazy `import nemo` raises and the model is marked FAILED

--- a/src/asr/ui/gradio_app.py
+++ b/src/asr/ui/gradio_app.py
@@ -63,10 +63,11 @@ def mount_ui(app: FastAPI) -> FastAPI:
                 allow_custom_value=False,
             )
         submit = gr.Button("Transcribe", variant="primary")
+        # Gradio 6 dropped the show_copy_button kwarg on Textbox (a copy
+        # affordance is built in by default). Don't pass it.
         result_box = gr.Textbox(
             label="Transcription",
             lines=8,
-            show_copy_button=True,
             visible=True,
         )
         ui.load(fn=lambda: gr.update(choices=available_choices()), outputs=model_dd)

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ test = [
 requires-dist = [
     { name = "cuda-python", marker = "sys_platform == 'linux'", specifier = ">=12.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.12" },
-    { name = "gradio", specifier = ">=5.33.1" },
+    { name = "gradio", specifier = ">=6.0,<7" },
     { name = "librosa", specifier = ">=0.11.0" },
     { name = "nemo-toolkit", extras = ["asr"], marker = "sys_platform == 'linux'", specifier = ">=2.4.0rc0" },
     { name = "opentelemetry-api", specifier = ">=1.27.0" },


### PR DESCRIPTION
## Symptom

\`GET /\` on v1.2.1 returns FastAPI's \`{\"detail\":\"Not Found\"}\` — the Gradio UI never mounted. Pod log:

\`\`\`
{\"exc_type\": \"TypeError\", \"event\": \"ui_mount_skipped\", ...}
\`\`\`

## Root cause

The previous pin was \`gradio>=5.33.1\` with no upper bound. The lockfile resolved to **gradio 6.13.0** (gradio 6.0 shipped recently). Gradio 6 dropped the \`show_copy_button\` kwarg from \`Textbox\` (the copy affordance is built in by default now). Our \`mount_ui()\` raised \`TypeError\` at mount time, the try/except in \`app.py\` swallowed it, and the app came up with no \`/\` route.

Reproduced inside the running pod:

\`\`\`
TypeError: Textbox.__init__() got an unexpected keyword argument 'show_copy_button'
\`\`\`

## Fix

- \`src/asr/ui/gradio_app.py\` — drop the \`show_copy_button=True\` kwarg. UX is unchanged (gradio 6 shows the affordance by default).
- \`pyproject.toml\` — pin \`gradio>=6.0,<7\`. The previous open upper bound is what let this happen silently; the explicit upper bound forces a deliberate review when gradio 7 ships.
- \`uv.lock\` regenerated.

## Test plan

- [x] \`uv run pytest\` — 48 passed.
- [x] \`uvx ruff check src/asr tests\` — clean.
- [ ] After release: bump deployment to the new tag; \`GET /\` should serve the Gradio UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)